### PR TITLE
Add exception handling for invalid IP

### DIFF
--- a/easy_timezones/middleware.py
+++ b/easy_timezones/middleware.py
@@ -4,6 +4,7 @@ from django.contrib.auth import get_user_model
 from django.utils import timezone
 import pytz
 import pygeoip
+import socket
 
 from .signals import detected_timezone
 from .utils import get_ip_address_from_request
@@ -40,8 +41,12 @@ class EasyTimezoneMiddleware(object):
 
             ip = get_ip_address_from_request(request)
             if ip != '127.0.0.1':
-                # if not local, fetch the timezone from pygeoip
-                tz = db.time_zone_by_addr(ip)
+                try:
+                    # if not local, fetch the timezone from pygeoip
+                    tz = db.time_zone_by_addr(ip)
+                except socket.error:
+                    # unable find the ip, just keep the default
+                    pass
 
         if tz:
             timezone.activate(tz)


### PR DESCRIPTION
We receive periodic middleware errors from by users with unresolvable IPs (mini-stacktrace attached)

This fix will handle those unresolvable IPs.

```
...
 File "/srv/virtualenv/current/local/lib/python2.7/site-packages/easy_timezones/middleware.py", line 42, in process_request
   tz = db.time_zone_by_addr(ip)

 File "/srv/virtualenv/current/local/lib/python2.7/site-packages/pygeoip/__init__.py", line 596, in time_zone_by_addr
   ipnum = util.ip2long(addr)

 File "/srv/virtualenv/current/local/lib/python2.7/site-packages/pygeoip/util.py", line 39, in ip2long
   return int(binascii.hexlify(socket.inet_pton(socket.AF_INET6, ip)), 16)

error: illegal IP address string passed to inet_pton
```