### PR TITLE
fixes #6, error: illegal IP address string passed to inet_pton

### DIFF
--- a/easy_timezones/middleware.py
+++ b/easy_timezones/middleware.py
@@ -1,4 +1,3 @@
-from django.core.exceptions import ImproperlyConfigured
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.utils import timezone
@@ -6,25 +5,32 @@ import pytz
 import pygeoip
 
 from .signals import detected_timezone
-from .utils import get_ip_address_from_request
-
-
-GEOIP_DATABASE = getattr(settings, 'GEOIP_DATABASE', None)
-
-if not GEOIP_DATABASE:
-    raise ImproperlyConfigured("GEOIP_DATABASE setting has not been defined.")
-
 
 db_loaded = False
 db = None
 
-
 def load_db():
     global db
-    db = pygeoip.GeoIP(GEOIP_DATABASE, pygeoip.MEMORY_CACHE)
+    db = pygeoip.GeoIP(settings.GEOIP_DATABASE, pygeoip.MEMORY_CACHE)
 
     global db_loaded
     db_loaded = True
+
+def get_client_ip(request):
+    x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
+    if x_forwarded_for:
+        ip = x_forwarded_for.split(',')[0]
+    else:
+        ip = request.META.get('REMOTE_ADDR')
+
+    return ip
+
+
+def is_valid_ip(ip):
+    import re
+    valid_ipv4_pattern = r'^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'
+    valid_ipv6_pattern = r'^\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?\s*$'
+    return bool(re.match(valid_ipv4_pattern, ip)) == True or bool(re.match(valid_ipv4_pattern, ip)) == True
 
 
 class EasyTimezoneMiddleware(object):
@@ -38,10 +44,12 @@ class EasyTimezoneMiddleware(object):
             # use the default timezone (settings.TIME_ZONE) for localhost
             tz = timezone.get_default_timezone()
 
-            ip = get_ip_address_from_request(request)
-            if ip != '127.0.0.1':
-                # if not local, fetch the timezone from pygeoip
-                tz = db.time_zone_by_addr(ip)
+            client_ip = get_client_ip(request)
+            ip_addrs = client_ip.split(',')
+            for ip in ip_addrs:
+                if is_valid_ip(ip) and ip != '127.0.0.1':
+                    tz = db.time_zone_by_addr(ip)
+                    break
 
         if tz:
             timezone.activate(tz)


### PR DESCRIPTION
The illegal IP usually comes up when the user is behind a proxy and gets comma separated values which might also have strings in it. We use this library in our project and faced this issue quite often. This fix works nicely for us and I hope for others too. Please take a look and merge if you are happy with the patch. 

Thanks!