### PR TITLE
Add support for Django 1.9 and Python 3.4

### DIFF
--- a/easy_timezones/urls.py
+++ b/easy_timezones/urls.py
@@ -1,6 +1,8 @@
 from django.conf.urls import url
 
+from . import views
+
 urlpatterns = [
-    url(r'^without_tz/$', 'easy_timezones.views.without_tz', name="without_tz"),
-    url(r'^with_tz/$', 'easy_timezones.views.with_tz', name="with_tz"),
+    url(r'^without_tz/$', views.without_tz, name="without_tz"),
+    url(r'^with_tz/$', views.with_tz, name="with_tz"),
 ]

--- a/easy_timezones/utils.py
+++ b/easy_timezones/utils.py
@@ -10,7 +10,7 @@ def is_valid_ip(ip_address):
     try:
         ip = ipaddress.ip_address(u'' + ip_address)
         return True
-    except ValueError, e:
+    except ValueError as e:
         return False
 
 def is_local_ip(ip_address):
@@ -19,7 +19,7 @@ def is_local_ip(ip_address):
     try:
         ip = ipaddress.ip_address(u'' + ip_address)
         return ip.is_loopback
-    except ValueError, e:
+    except ValueError as e:
         return None
 
 def get_ip_address_from_request(request):

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,3 +1,7 @@
+import django
+DJANGO_18_PLUS = django.VERSION[:2] >= (1, 8)
+DJANGO_18_PLUS_APPS = ['django.contrib.auth', 'django.contrib.contenttypes']
+DJANGO_APPS_ALL_VERSIONS = ['django.contrib.sessions', 'easy_timezones']
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
@@ -5,11 +9,16 @@ DATABASES = {
     }
 }
 SECRET_KEY = "secret_key_for_testing"
-INSTALLED_APPS = ['django.contrib.sessions', 'easy_timezones']
 MIDDLEWARE_CLASSES = ['django.contrib.sessions.middleware.SessionMiddleware', 'easy_timezones.middleware.EasyTimezoneMiddleware']
 GEOIP_DATABASE = 'GeoLiteCity.dat' 
 ROOT_URLCONF = 'easy_timezones.urls'
+DEBUG = True
 TIME_ZONE = 'UTC'
 ALLOWED_HOSTS = ["*"]
-DEBUG = True
 AUTH_USER_MODEL = None
+
+if DJANGO_18_PLUS:
+	INSTALLED_APPS = DJANGO_18_PLUS_APPS + DJANGO_APPS_ALL_VERSIONS
+	TEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates'}]
+else:
+	INSTALLED_APPS = DJANGO_APPS_ALL_VERSIONS


### PR DESCRIPTION
There was a syntax problem in the utils.py file where "except ValueError, e" should be "except ValueError as e" instead to support both python 2 and 3.

Django 1.8 and up requires the template backend to be defined as well.

Hope this helps!
