### PR TITLE
Add support for Django 1.10-style middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.pot
 *.pyc
 .coverage
+.tox
 django_easy_timezones.egg-info/
 env/
 dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,25 @@
 language: python
 python:
-  - "2.7"
   - "3.5"
+
+env:
+  - TOX_ENV=py27-django110
+  - TOX_ENV=py35-django110
+  - TOX_ENV=py34-django110
+  - TOX_ENV=py35-django19
+  - TOX_ENV=py34-django19
+  - TOX_ENV=py27-django19
+  - TOX_ENV=py35-django18
+  - TOX_ENV=py34-django18
+  - TOX_ENV=py33-django18
+  - TOX_ENV=py27-django18
+  - TOX_ENV=py34-django17
+  - TOX_ENV=py33-django17
+  - TOX_ENV=py27-django17
+
 # command to install dependencies
 install:
-  - "pip install -r requirements.txt"
+  - pip install tox
 # command to run tests
-script: python manage.py test 
+script:
+    - tox -e $TOX_ENV

--- a/easy_timezones/middleware.py
+++ b/easy_timezones/middleware.py
@@ -1,3 +1,4 @@
+import django
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ImproperlyConfigured
@@ -47,7 +48,15 @@ def load_db():
     global db_loaded
     db_loaded = True
 
-class EasyTimezoneMiddleware(deprecation.MiddlewareMixin):
+
+if django.VERSION >= (1, 10):
+    from django.utils.deprecation import MiddlewareMixin
+    middleware_base_class = MiddlewareMixin
+else:
+    middleware_base_class = object
+
+
+class EasyTimezoneMiddleware(middleware_base_class):
     def process_request(self, request):
         """
         If we can get a valid IP from the request,
@@ -84,7 +93,7 @@ class EasyTimezoneMiddleware(deprecation.MiddlewareMixin):
         if tz:
             timezone.activate(tz)
             request.session['django_timezone'] = str(tz)
-            if getattr(settings, 'AUTH_USER_MODEL', None):
+            if getattr(settings, 'AUTH_USER_MODEL', None) and getattr(request, 'user', None):
                 detected_timezone.send(sender=get_user_model(), instance=request.user, timezone=tz)
         else:
             timezone.deactivate()

--- a/easy_timezones/middleware.py
+++ b/easy_timezones/middleware.py
@@ -2,7 +2,7 @@ import django
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import timezone, deprecation
+from django.utils import timezone
 import pytz
 import pygeoip
 import os

--- a/easy_timezones/middleware.py
+++ b/easy_timezones/middleware.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import timezone
+from django.utils import timezone, deprecation
 import pytz
 import pygeoip
 import os
@@ -47,7 +47,7 @@ def load_db():
     global db_loaded
     db_loaded = True
 
-class EasyTimezoneMiddleware(object):
+class EasyTimezoneMiddleware(deprecation.MiddlewareMixin):
     def process_request(self, request):
         """
         If we can get a valid IP from the request,

--- a/easy_timezones/urls.py
+++ b/easy_timezones/urls.py
@@ -1,6 +1,8 @@
 from django.conf.urls import url
 
+from . import views
+
 urlpatterns = [
-    url(r'^without_tz/$', 'easy_timezones.views.without_tz', name="without_tz"),
-    url(r'^with_tz/$', 'easy_timezones.views.with_tz', name="with_tz"),
+    url(r'^without_tz/$', views.without_tz, name="without_tz"),
+    url(r'^with_tz/$', views.with_tz, name="with_tz"),
 ]

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,4 +1,4 @@
-Django>=1.7
+coverage==4.1
 ipaddress==1.0.16
 pygeoip==0.3.2
 pytz==2016.6

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,3 +1,6 @@
+import django
+
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
@@ -6,10 +9,41 @@ DATABASES = {
 }
 SECRET_KEY = "secret_key_for_testing"
 INSTALLED_APPS = ['django.contrib.auth', 'django.contrib.sites', 'django.contrib.sessions', 'django.contrib.contenttypes', 'easy_timezones']
-MIDDLEWARE_CLASSES = ['django.contrib.sessions.middleware.SessionMiddleware', 'easy_timezones.middleware.EasyTimezoneMiddleware']
-GEOIP_DATABASE = 'GeoLiteCity.dat' 
+GEOIP_DATABASE = 'GeoLiteCity.dat'
 ROOT_URLCONF = 'easy_timezones.urls'
 TIME_ZONE = 'UTC'
 ALLOWED_HOSTS = ["*"]
 DEBUG = True
-AUTH_USER_MODEL = None
+
+if django.VERSION < (1, 8):
+    # satisfy tests in django 1.7
+    AUTH_USER_MODEL = 'auth.User'
+else:
+    AUTH_USER_MODEL = None
+
+if django.VERSION >= (1, 9):
+    # satisfy deprecation warning in 1.9 and failure in 1.10
+    TEMPLATES = [
+        {
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'DIRS': [],
+            'APP_DIRS': True,
+            'OPTIONS': {
+                'context_processors': [
+                    'django.contrib.auth.context_processors.auth',
+                    'django.template.context_processors.debug',
+                    'django.template.context_processors.i18n',
+                    'django.template.context_processors.media',
+                    'django.template.context_processors.static',
+                    'django.template.context_processors.tz',
+                    'django.contrib.messages.context_processors.messages',
+                ],
+            },
+        },
+    ]
+
+if django.VERSION >= (1, 10):
+    # use new MIDDLEWARE introduced in 1.10
+    MIDDLEWARE = ['django.contrib.sessions.middleware.SessionMiddleware', 'easy_timezones.middleware.EasyTimezoneMiddleware']
+else:
+    MIDDLEWARE_CLASSES = ['django.contrib.sessions.middleware.SessionMiddleware', 'easy_timezones.middleware.EasyTimezoneMiddleware']

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+envlist =
+    {py27,py33,py34}-django17,
+    {py27,py33,py34,py35}-django18,
+    {py27,py34,py35}-django19,
+    {py27,py34,py35}-django110,
+
+[testenv]
+commands = python manage.py test
+deps =
+    django17: Django>=1.7,<1.8
+    django18: Django>=1.8,<1.9
+    django19: Django>=1.9,<1.10
+    django110: Django>=1.10,<1.11
+    -rrequirements-testing.txt
+basepython =
+    py35: python3.5
+    py34: python3.4
+    py33: python3.3
+    py27: python2.7


### PR DESCRIPTION
There may be more to do here (or you may want to handle it differently), but this seems to be an easy way to add support for the new way that middleware works in Django 1.10.

https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-middleware
