### PR TITLE
Update Django Signal creation for Django > 3.1

### DIFF
--- a/easy_timezones/signals.py
+++ b/easy_timezones/signals.py
@@ -1,4 +1,4 @@
 # Django
 import django.dispatch
 
-detected_timezone = django.dispatch.Signal(providing_args=["instance", "timezone"])
+detected_timezone = django.dispatch.Signal()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django>=1.7
 ipaddress==1.0.16
 pygeoip==0.3.2
-pytz==2016.6
+pytz>=2016.6
 wheel==0.29.0


### PR DESCRIPTION
In Django 3.1 (https://docs.djangoproject.com/en/4.0/releases/3.1/), the Signal class was changed: "The purely documentational providing_args argument for Signal is deprecated. If you rely on this argument as documentation, you can move the text to a code comment or docstring."